### PR TITLE
Rework of booster card selection

### DIFF
--- a/src/utils/cardSelectionUtils.ts
+++ b/src/utils/cardSelectionUtils.ts
@@ -2,16 +2,42 @@ import { CardsModel } from "../model/CardsModel";
 import { getRandomCard } from "../utils/getRandomCard";
 
 export function selectCards(cards: CardsModel[]): CardsModel[] {
-  const selectedCards = Array.from({ length: 4 }, () => getRandomCard(cards));
+  const randomChance = Math.random() * 100;
 
-  const filteredCards = cards.filter(
-    (card) => card.official_rate && card.official_rate <= 30
-  );
-  if (filteredCards.length === 0) {
-    throw new Error("Aucune carte avec un official_rate <= 30 trouvée.");
+  if (randomChance <= 0.5) {
+    const ultraRareCards = cards.filter(
+      (card) => card.official_rate && card.official_rate < 3
+    );
+    if (ultraRareCards.length === 0) {
+      throw new Error(
+        "Aucune carte avec un official_rate < 3% trouvée pour le pack spécial."
+      );
+    }
+
+    return Array.from({ length: 5 }, () => getRandomCard(ultraRareCards));
   }
 
-  const fifthCard = getRandomCard(filteredCards);
+  const commonCards = cards.filter(
+    (card) => card.official_rate && card.official_rate >= 1
+  );
+  if (commonCards.length === 0) {
+    throw new Error("Aucune carte avec un official_rate >= 1% trouvée.");
+  }
+
+  const selectedCards = Array.from({ length: 3 }, () =>
+    getRandomCard(commonCards)
+  );
+
+  selectedCards.push(getRandomCard(cards));
+
+  const rareCards = cards.filter(
+    (card) => card.official_rate && card.official_rate <= 30
+  );
+  if (rareCards.length === 0) {
+    throw new Error("Aucune carte avec un official_rate <= 30% trouvée.");
+  }
+
+  const fifthCard = getRandomCard(rareCards);
   selectedCards.push(fifthCard);
 
   return selectedCards;

--- a/src/utils/cardSelectionUtils.ts
+++ b/src/utils/cardSelectionUtils.ts
@@ -4,7 +4,9 @@ import { getRandomCard } from "../utils/getRandomCard";
 export function selectCards(cards: CardsModel[]): CardsModel[] {
   const randomChance = Math.random() * 100;
 
-  if (randomChance <= 0.5) {
+  const goldenPack = 0.5;
+
+  if (randomChance <= goldenPack) {
     const ultraRareCards = cards.filter(
       (card) => card.official_rate && card.official_rate < 3
     );


### PR DESCRIPTION
Rework of card selection for boosters : 
- Now the 3 first cards can't be a legendary card.
- You now have 0.50% to get a Golden Pack, wich gives only ultra rare holo and legendary cards. 